### PR TITLE
add docker-compose.armhf.yaml for RaspberryPi 3b,armhf platform

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -93,6 +93,29 @@ services:
 ```
 然后使用 `docker-compose up -d` 运行即可
 
+为了能让例子更具体，我建立了一个实例[docker-compose.armhf.yaml](/docker-compose.armhf.yaml)
+
+   其中`PGID=1000`,`PUID=1000`指定了用户组和用户ID，都为1000，这个是在树莓派系统里面，用户pi的属性
+   
+   在建立`/home/pi/data`的时候，需要用到如下命令,其中的用户pi,可以是你自己创建的其它用户名（例如abc)
+   ```
+   mkdir /home/pi/data
+   chown pi:pi -R /home/pi/data
+   ```
+   `database.db`这个是文件管理器需要用到的数据库，用于存放数据，对应当前目录下面的`./app/filebrowser.db`
+   创建./app/filebrowser.db方法比较简单，直接一条touch命令就可以了
+   ```
+   mkdir app
+   touch app/filebrowser.db
+   chown pi:pi app/filebrowser.db
+   ```
+   启动树莓派的实例，需要用到如下命令
+   ```
+   docker-compose -f docker-compose.armhf.yaml up -d
+   ```
+   登陆树莓派Aria2的用户为`pi`,密码`raspberry`
+   
+
 ### 支持的 Docker 环境变量
 
   * ENABLE_AUTH 启用 Basic auth(网页简单认证) 用户认证

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ English | [简体中文](https://github.com/wahyd4/aria2-ariang-docker/blob/mast
   - [Quick run](#quick-run)
   - [Full features run](#full-features-run)
   - [Run with docker-compose](#run-with-docker-compose)
+  - [Docker-compose example](#docker-compose-example)
   - [Supported Environment Variables](#supported-environment-variables)
   - [Supported Volumes](#supported-volumes)
 - [Auto SSL enabling](#auto-ssl-enabling)
@@ -98,6 +99,35 @@ services:
       - ./data:/data
 ```
 Then just run `docker-compose up -d`, that's it!
+
+### Docker-compose example
+
+In order to make the project easier to understand, I created an example [docker-compose.armhf.yaml](/docker-compose.armhf.yaml)
+
+   `PGID=1000`,`PUID=1000` is for RaspberyPi system user pi
+   
+   when create `/home/pi/data`,cmd we use(you can change pi as what you like,but it must the use name of Raspbian system)
+   ```
+   mkdir /home/pi/data
+   chown pi:pi -R /home/pi/data
+   ```
+   
+  `database.db` corresponds to the `./app/filebrowser.db` file of the Raspbian system.
+   how to create `./app/filebrowser.db`
+   ```
+   mkdir app
+   touch app/filebrowser.db
+   chown pi:pi app/filebrowser.db
+   ```
+   Bring up raspberry aria2ng just use cmd:
+   ```
+   docker-compose -f docker-compose.armhf.yaml up -d
+   ```
+   How to login
+   ```
+   username = pi
+   password = raspberry
+   ```
 
 ### Supported Environment Variables
 

--- a/docker-compose.armhf.yaml
+++ b/docker-compose.armhf.yaml
@@ -3,7 +3,7 @@ services:
   aria2-ui:
     restart: unless-stopped
     image: wahyd4/aria2-ui:arm32
-    container_name: RpiAria2
+    container_name: rpi_aria2_armhf
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.armhf.yaml
+++ b/docker-compose.armhf.yaml
@@ -1,0 +1,20 @@
+version: "3.5"
+services:
+  aria2-ui:
+    restart: unless-stopped
+    image: wahyd4/aria2-ui:arm32
+    container_name: RpiAria2
+    ports:
+      - "80:80"
+      - "443:443"
+      - "6800:6800"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - ENABLE_AUTH=true
+      - ARIA2_USER=pi
+      - ARIA2_PWD=raspberry
+      - DOMAIN=:80
+    volumes:
+      - /home/pi/data:/data # /home/pi/data owner must be user pi,chown pi:pi /home/pi/data
+      - ./app/filebrowser.db:/database.db


### PR DESCRIPTION
添加`docker-compose.armhf.yaml`
主要目的是，方便在树莓派3B上直接运行
/home/pi/data 需要使用`chown pi:pi  -R /home/pi/data`来更换所有者权限为pi用户
因为定义了 PGID，PUID都为1000
./app/filebrowser.db需要用`touch filebrowser.db`来创建，完成后使用`chown pi:pi ./app/filebrowser.db`更改用户所有者为pi
在树莓派上运行(添加-d,用于后台运行）
docker-compose -f docker-compose.armhf up -d
