### PR TITLE
Rclone

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -21,8 +21,7 @@
   root /usr/local/www/aria2
   timeouts none
   gzip
-  log stdout
-  errors stdout
+  errors stderr
 }
 
 {$DOMAIN}/rclone {
@@ -33,7 +32,6 @@
   proxy / 127.0.0.1:5572/ {
     transparent
   }
-
-  log stdout
+  gzip
   errors stderr
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -24,3 +24,16 @@
   log stdout
   errors stdout
 }
+
+{$DOMAIN}/rclone {
+  redir / /rclone/ 301
+}
+
+{$DOMAIN}/rclone/ {
+  proxy / 127.0.0.1:5572/ {
+    transparent
+  }
+
+  log stdout
+  errors stderr
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV ARIA2_EXTERNAL_PORT=80
 ENV PUID=1000
 ENV PGID=1000
 ENV CADDYPATH=/app
-ENV RCLONE_CONFIG=/app/conf/rclone/rclone.conf
+ENV RCLONE_CONFIG=/app/conf/rclone.conf
 
 RUN adduser -D -u 1000 junv \
   && apk update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,17 @@ RUN adduser -D -u 1000 junv \
   && rm -rf forego-stable-${platform}.tgz \
   && mkdir -p /usr/local/www \
   && mkdir -p /usr/local/www/aria2 \
-  && rm -rf init /app/*.txt
+  && rm -rf init /app/*.txt \
+  && curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip \
+  && unzip rclone-current-linux-amd64.zip \
+  && cd rclone-*-linux-amd64 \
+  && cp rclone /usr/local/bin/ \
+  && chown junv:junv /usr/local/bin/rclone \
+  && chmod 755 /usr/local/bin/rclone \
+  && rm /app/rclone-current-linux-amd64.zip \
+  && rm -rf /app/rclone-*-linux-amd64
 
-ADD aria2c.sh caddy.sh Procfile init.sh start.sh /app/
+ADD aria2c.sh caddy.sh Procfile init.sh start.sh rclone.sh /app/
 ADD conf /app/conf
 ADD Caddyfile SecureCaddyfile /usr/local/caddy/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,13 @@ RUN adduser -D -u 1000 junv \
   && mkdir -p /usr/local/www/aria2 \
   && rm -rf init /app/*.txt \
   && curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip \
-  && unzip rclone-current-linux-amd64.zip \
-  && cd rclone-*-linux-amd64 \
+  && unzip rclone-*.zip \
+  && cd rclone-* \
   && cp rclone /usr/local/bin/ \
   && chown junv:junv /usr/local/bin/rclone \
   && chmod 755 /usr/local/bin/rclone \
-  && rm /app/rclone-current-linux-amd64.zip \
-  && rm -rf /app/rclone-*-linux-amd64
+  && rm /app/rclone-*.zip \
+  && rm -rf /app/rclone-*
 
 ADD aria2c.sh caddy.sh Procfile init.sh start.sh rclone.sh /app/
 ADD conf /app/conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV ARIA2_EXTERNAL_PORT=80
 ENV PUID=1000
 ENV PGID=1000
 ENV CADDYPATH=/app
+ENV RCLONE_CONFIG=/app/conf/rclone/rclone.conf
 
 RUN adduser -D -u 1000 junv \
   && apk update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN adduser -D -u 1000 junv \
   && rm -rf init /app/*.txt \
   && curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip \
   && unzip rclone-*.zip \
-  && cd rclone-* \
+  && cd rclone-*-linux-amd64 \
   && cp rclone /usr/local/bin/ \
   && chown junv:junv /usr/local/bin/rclone \
   && chmod 755 /usr/local/bin/rclone \

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 filebrowser: /app/filebrowser -p 8080 -d /app/filebrowser.db -r /data
 caddy: /app/caddy.sh
 aria2c: /app/aria2c.sh
+rclone: /app/rclone.sh

--- a/README.CN.md
+++ b/README.CN.md
@@ -32,8 +32,9 @@ File Browser
 
 ## 功能特性
 
-  * Aria2 (SSL 支持)
-  * AriaNg 通过 UI 来操作，下载文件
+  * [Aria2](https://aria2.github.io) 文件下载工具(支持SSL )
+  * [AriaNg](https://github.com/mayswind/AriaNg) 通过 UI 来操作，下载文件
+  * [Rclone](https://rclone.org) 同步文件到云盘
   * 自动 HTTPS （Let's Encrypt）
   * 支持绑定自定义用户ID，可以主机上的非`root`用户，也可以管理下载的文件
   * Basic Auth 用户认证
@@ -58,7 +59,7 @@ File Browser
 
 * Aria2: <http://yourip/ui/>
 * FileManger: <http://yourip>
-* 请使用 admin/admin 进行登录
+* 请使用 admin/admin 进行登录, 在如果没有修改`ARIA2_USER`,`ARIA2_PWD`的情况下，请使用`user`/`password`登录`Rclone`
 ### 开启所有功能
 ```bash
   docker run -d --name ariang \
@@ -76,7 +77,7 @@ File Browser
   -v /yourdata:/data \
   -v /app/a.db:/app/filebrowser.db \
   -v /yoursslkeys/:/app/conf/key \
-  -v <the folder of aria2.conf and aria2.session>:/app/conf \
+  -v <conf files folder>:/app/conf \
   wahyd4/aria2-ui
 ```
 ### 使用docker-compose 运行
@@ -101,8 +102,8 @@ services:
 ### 支持的 Docker 环境变量
 
   * ENABLE_AUTH 启用 Basic auth(网页简单认证) 用户认证
-  * ARIA2_USER Basic Auth 用户认证用户名
-  * ARIA2_PWD Basic Auth 密码
+  * ARIA2_USER Basic Auth 用户认证用户名，Rclone也使用该参数
+  * ARIA2_PWD Basic Auth 密码，Rclone也使用该参数
   * ARIA2_EXTERNAL_PORT 从外部可以访问到的 Aria2 端口，默认为 HTTP 的`80`
   * PUID 需要绑定主机的Linux用户ID，可以通过`cat /etc/passwd` 查看用户列表， 默认UID 是`1000`
   * PGID 需要绑定的主机的Linux 用户组ID，默认GID 是`1000`
@@ -113,7 +114,10 @@ services:
 ### 支持的 Docker volume 属性
   * `/data` 用来放置所有下载的文件的目录
   * `/app/conf/key` 用户来放置 Aria2 SSL `certificate`证书和 `key` 文件. `注意`: 证书的名字必须是 `aria2.crt`， Key 文件的名字必须是 `aria2.key`
-  * `/app/conf` 该目录下可以放置你的自定义`aria2.conf`配置文件，`aria2.session`，且必须包含这两个文件。第一次使用`aria2.session`时，创建一个空文件即可，该文件会包含aria2当前的下载列表，这样即使容器被销毁也不用担心文件列表丢失了。你也可以直接拷贝当前项目下`conf`目录中的两个文件并使用。
+  * `/app/conf` 该目录下可以放置你的自定义`aria2.conf`配置文件，`aria2.session`，且必须包含这两个文件。第一次使用`aria2.session`时，创建一个空文件即可，该文件会包含aria2当前的下载列表，这样即使容器被销毁也不用担心文件列表丢失了。你也可以直接拷贝当前项目下`conf`目录中的两个文件并使用。如需映射rclone.conf到容器内，请将其就放置于该目录下。因此配置文件目录支持的所有配置文件为：
+    * aria2.conf
+    * aria2.session
+    * rclone.conf
   * `/app/filebrowser.db` File Browser 的内嵌数据库，升级Docker 镜像也不用担心之前的设置丢失。请确保在宿主机先创建一个空文件再使用。
 
 ## 自动 SSL

--- a/README.CN.md
+++ b/README.CN.md
@@ -59,6 +59,7 @@ File Browser
 
 * Aria2: <http://yourip/ui/>
 * FileManger: <http://yourip>
+* Rclone: <http://yourip/rclone>
 * 请使用 admin/admin 进行登录, 在如果没有修改`ARIA2_USER`,`ARIA2_PWD`的情况下，请使用`user`/`password`登录`Rclone`
 ### 开启所有功能
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ File Browser
 
 ## Features
 
-  * Aria2 (SSL support)
-  * AriaNg
+  * [Aria2 (SSL support)](https://aria2.github.io)
+  * [AriaNg](https://github.com/mayswind/AriaNg)
+  * [Rclone](https://rclone.org/)
   * Auto HTTPS （Let's Encrypt）
   * Bind non root user into container, so non root user can also manage downloaded files.
   * Basic Auth
@@ -65,7 +66,8 @@ File Browser
 
 * Aria2: <http://yourip/ui/>
 * FileManger: <http://yourip>
-* Please use `admin`/`admin` as username and password to login for the first time.
+* Rclone: <http://yourip/rclone>
+* Please use `admin`/`admin` as username and password to login for the first time, and `user`/`password` to login `Rclone` if you don't change `ARIA2_USER` and `ARIA2_PWD`
 
 ### Full features run
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ File Browser
 * Aria2: <http://yourip/ui/>
 * FileManger: <http://yourip>
 * Rclone: <http://yourip/rclone>
-* Please use `admin`/`admin` as username and password to login for the first time, and `user`/`password` to login `Rclone` if you don't change `ARIA2_USER` and `ARIA2_PWD`
+* Please use `admin`/`admin` as username and password to login for the first time, and `user`/`password` to login `Rclone` if you don't update `ARIA2_USER` and `ARIA2_PWD`
 
 ### Full features run
 
@@ -86,8 +86,8 @@ File Browser
   -e ARIA2_EXTERNAL_PORT=443 \
   -v /yourdata:/data \
   -v /app/a.db:/app/filebrowser.db \
-  -v /yoursslkeys/:/app/conf/key \
-  -v <the folder of aria2.conf and aria2.session>:/app/conf \
+  -v /to_yoursslkeys/:/app/conf/key \
+  -v <conf files folder>:/app/conf \
   wahyd4/aria2-ui
 ```
 ### Run with docker-compose
@@ -114,8 +114,8 @@ Then just run `docker-compose up -d`, that's it!
 ### Supported Environment Variables
 
   * ENABLE_AUTH whether to enable Basic auth
-  * ARIA2_USER Basic Auth username
-  * ARIA2_PWD Basic Auth password
+  * ARIA2_USER Basic Auth username, Rclone GUI uses it as well.
+  * ARIA2_PWD Basic Auth password, Rclone GUI uses it as well.
   * ARIA2_EXTERNAL_PORT The Aria2 port which exposed to public to access to
   * PUID Bind Linux UID into container which means you can use non `root` user to manage downloaded files, default UID is `1000`
   * PGID Bind Linux GID into container, default GID is 1000
@@ -126,7 +126,12 @@ Then just run `docker-compose up -d`, that's it!
 ### Supported Volumes
   * `/data` The folder which contains all the files you download.
   * `/app/conf/key` The folder which stored Aria2 SSL `certificate` and `key` file. `Notice`: The certificate file should be named `aria2.crt` and the key file should be named `aria2.key`
-  * `/app/conf` The Aria2 configuration and file session folder. Make sure you have `aria2.conf` and `aria2.session` file. For the first time `aria2.session` just need to be a empty file can be appended. You can also user the templates for these two file in the `conf` folder of this project. **Warning: if you don't mount `/app/conf`, whenever the container restart, you'll lose your downloading progress.**
+  * `/app/conf` The Aria2 configuration and file session folder. Make sure you have `aria2.conf` and `aria2.session` file. For the first time `aria2.session` just need to be a empty file can be appended. You can also user the templates for these two file in the `conf` folder of this project. Please put your `rclone.conf` in this folder as well if you'd mount it to Rclone. So all the config files supported in this folder are:
+    * aria2.conf
+    * aria2.session
+    * rclone.conf
+
+    **Warning: if you don't mount `/app/conf`, whenever the container restarts, you'll lose your downloading progress.**
   * `/app/filebrowser.db` File Browser settings database, make sure you make a empty file first on your host.
 
 ## Auto SSL enabling

--- a/SecureCaddyfile
+++ b/SecureCaddyfile
@@ -8,6 +8,10 @@
     websocket
   }
 
+  proxy /rclone 127.0.0.1:5572 {
+    transparent
+  }
+
   gzip
   log stdout
   errors stdout
@@ -25,4 +29,17 @@
   errors stdout
 
   basicauth / {$ARIA2_USER} {$ARIA2_PWD}
+}
+
+{$DOMAIN}/rclone {
+  redir / /rclone/ 301
+}
+
+{$DOMAIN}/rclone/ {
+  proxy / 127.0.0.1:5572/ {
+    transparent
+  }
+
+  log stdout
+  errors stderr
 }

--- a/SecureCaddyfile
+++ b/SecureCaddyfile
@@ -13,8 +13,7 @@
   }
 
   gzip
-  log stdout
-  errors stdout
+  errors stderr
 }
 
 {$DOMAIN}/ui {
@@ -25,8 +24,7 @@
   root /usr/local/www/aria2
   timeouts none
   gzip
-  log stdout
-  errors stdout
+  errors stderr
 
   basicauth / {$ARIA2_USER} {$ARIA2_PWD}
 }
@@ -39,7 +37,6 @@
   proxy / 127.0.0.1:5572/ {
     transparent
   }
-
-  log stdout
+  gzip
   errors stderr
 }

--- a/arm32.Dockerfile
+++ b/arm32.Dockerfile
@@ -14,7 +14,7 @@ ENV ARIA2_EXTERNAL_PORT=80
 ENV PUID=1000
 ENV PGID=1000
 ENV CADDYPATH=/app
-ENV RCLONE_CONFIG=/app/conf/rclone/rclone.conf
+ENV RCLONE_CONFIG=/app/conf/rclone.conf
 
 RUN adduser -D -u 1000 junv \
   && apk update \

--- a/arm32.Dockerfile
+++ b/arm32.Dockerfile
@@ -14,11 +14,16 @@ ENV ARIA2_EXTERNAL_PORT=80
 ENV PUID=1000
 ENV PGID=1000
 ENV CADDYPATH=/app
+ENV RCLONE_CONFIG=/app/conf/rclone/rclone.conf
 
 RUN adduser -D -u 1000 junv \
   && apk update \
   && apk add runit shadow wget bash curl openrc gnupg aria2 tar --no-cache \
-  && curl https://getcaddy.com | bash -s personal \
+  && caddy_tag=v1.0.4 \
+  && wget -N https://github.com/caddyserver/caddy/releases/download/${caddy_tag}/caddy_${caddy_tag}_linux_arm7.tar.gz \
+  && tar -zxvf caddy_*.tar.gz \
+  && mv caddy /usr/local/bin/ \
+  && rm -rf caddy_*.tar.gz \
   && filebrowser_version=v2.2.0 \
   && platform=linux-armv6 \
   && wget -N https://github.com/filebrowser/filebrowser/releases/download/${filebrowser_version}/${platform}-filebrowser.tar.gz \
@@ -29,9 +34,18 @@ RUN adduser -D -u 1000 junv \
   && tar -zxvf forego-stable-linux-arm.tgz \
   && rm -rf forego-stable-linux-arm.tgz \
   && mkdir -p /usr/local/www \
-  && mkdir -p /usr/local/www/aria2
+  && mkdir -p /usr/local/www/aria2 \
+  && rm -rf init /app/*.txt \
+  && curl -O https://downloads.rclone.org/v1.53.0/rclone-v1.53.0-linux-arm.zip \
+  && unzip rclone-*.zip \
+  && cd rclone-* \
+  && cp rclone /usr/local/bin/ \
+  && chown junv:junv /usr/local/bin/rclone \
+  && chmod 755 /usr/local/bin/rclone \
+  && rm /app/rclone-*.zip \
+  && rm -rf /app/rclone-*
 
-ADD aria2c.sh caddy.sh Procfile init.sh start.sh /app/
+ADD aria2c.sh caddy.sh Procfile init.sh start.sh rclone.sh /app/
 ADD conf /app/conf
 ADD Caddyfile SecureCaddyfile /usr/local/caddy/
 

--- a/arm64.Dockerfile
+++ b/arm64.Dockerfile
@@ -18,7 +18,11 @@ ENV CADDYPATH=/app
 RUN adduser -D -u 1000 junv \
   && apk update \
   && apk add runit shadow wget bash curl openrc gnupg aria2 tar --no-cache \
-  && curl https://getcaddy.com | bash -s personal \
+  && caddy_tag=v1.0.4 \
+  && wget -N https://github.com/caddyserver/caddy/releases/download/${caddy_tag}/caddy_${caddy_tag}_linux_arm64.tar.gz \
+  && tar -zxvf caddy_*.tar.gz \
+  && mv caddy /usr/local/bin/ \
+  && rm -rf caddy_*.tar.gz \
   && filebrowser_version=v2.2.0 \
   && platform=linux-arm64 \
   && wget -N https://github.com/filebrowser/filebrowser/releases/download/${filebrowser_version}/${platform}-filebrowser.tar.gz \
@@ -29,9 +33,18 @@ RUN adduser -D -u 1000 junv \
   && tar -zxvf forego-stable-linux-arm64.tgz \
   && rm -rf forego-stable-linux-arm64.tgz \
   && mkdir -p /usr/local/www \
-  && mkdir -p /usr/local/www/aria2
+  && mkdir -p /usr/local/www/aria2 \
+  && rm -rf init /app/*.txt \
+  && curl -O https://downloads.rclone.org/v1.53.0/rclone-v1.53.0-linux-arm.zip \
+  && unzip rclone-*.zip \
+  && cd rclone-* \
+  && cp rclone /usr/local/bin/ \
+  && chown junv:junv /usr/local/bin/rclone \
+  && chmod 755 /usr/local/bin/rclone \
+  && rm /app/rclone-*.zip \
+  && rm -rf /app/rclone-*
 
-ADD aria2c.sh caddy.sh Procfile init.sh start.sh /app/
+ADD aria2c.sh caddy.sh Procfile init.sh start.sh rclone.sh /app/
 ADD conf /app/conf
 ADD Caddyfile SecureCaddyfile /usr/local/caddy/
 

--- a/arm64.Dockerfile
+++ b/arm64.Dockerfile
@@ -14,6 +14,7 @@ ENV ARIA2_EXTERNAL_PORT=80
 ENV PUID=1000
 ENV PGID=1000
 ENV CADDYPATH=/app
+ENV RCLONE_CONFIG=/app/conf/rclone.conf
 
 RUN adduser -D -u 1000 junv \
   && apk update \

--- a/init.sh
+++ b/init.sh
@@ -11,6 +11,7 @@ chown -R junv:junv \
          /data
 
 chmod +x /app/caddy.sh \
+         /app/rclone.sh \
          /app/aria2c.sh
 
 echo "**** give caddy permissions to use low ports ****"

--- a/rclone.sh
+++ b/rclone.sh
@@ -1,0 +1,8 @@
+#! /bin/bash -eu
+
+echo "Start Rclone"
+rclone rcd --rc-web-gui \
+  --rc-web-gui-no-open-browser \
+  --rc-addr :5572 \
+  --rc-user $ARIA2_USER \
+  --rc-pass $ARIA2_PWD

--- a/rclone.sh
+++ b/rclone.sh
@@ -5,4 +5,5 @@ rclone rcd --rc-web-gui \
   --rc-web-gui-no-open-browser \
   --rc-addr :5572 \
   --rc-user $ARIA2_USER \
-  --rc-pass $ARIA2_PWD
+  --rc-pass $ARIA2_PWD \
+  --cache-dir /app/.cache


### PR DESCRIPTION
Closes #110 #109 

This introduces changes of:
* Add rclone  support 🎉, now you can access Rclone at `/rclone`
* All of x64, arm32 and arm64 support Rclone