### PR TITLE
fix filebrowser inline preview problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD Caddyfile SecureCaddyfile /usr/local/caddy/
 
 RUN adduser -D -u 1000 junv \
   && apk update \
-  && apk add runit shadow wget bash curl openrc gnupg aria2 tar --no-cache \
+  && apk add runit shadow wget bash curl openrc gnupg aria2 tar mailcap --no-cache \
   && caddy_tag=v1.0.4 \
   && wget -N https://github.com/caddyserver/caddy/releases/download/${caddy_tag}/caddy_${caddy_tag}_linux_amd64.tar.gz \
   && tar -zxvf caddy_${caddy_tag}_linux_amd64.tar.gz \


### PR DESCRIPTION
fix the problem of missing /etc/mime.types causes filebrowser to not recognize some files as videos and thus not showing the inline preview window.