### PR TITLE
Offer a way to disable rclone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 ENV RPC_SECRET=""
 ENV ENABLE_AUTH=false
+ENV ENABLE_RCLONE=true
 ENV DOMAIN=http://localhost
 ENV ARIA2_USER=user
 ENV ARIA2_PWD=password

--- a/README.CN.md
+++ b/README.CN.md
@@ -103,6 +103,7 @@ services:
 ### 支持的 Docker 环境变量
 
   * ENABLE_AUTH 启用 Basic auth(网页简单认证) 用户认证
+  * ENABLE_RCLONE 是否启用 RCLONE，由于Rclone 的初次运行需要从Github 下载文件，由于你懂的原因，可能文件下载失败，进而导致整个程序崩溃,这时你需要设置为`false`
   * ARIA2_USER Basic Auth 用户认证用户名，Rclone也使用该参数
   * ARIA2_PWD Basic Auth 密码，Rclone也使用该参数
   * ARIA2_EXTERNAL_PORT 从外部可以访问到的 Aria2 端口，默认为 HTTP 的`80`

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Then simply run `docker-compose up -d`, that's it!
 ### Supported Environment Variables
 
   * ENABLE_AUTH whether to enable Basic auth
+  * ENABLE_RCLONE whether to disable Rclone, if you running this container offline or do not have stable connection to Github, please set to `false`
   * ARIA2_USER Basic Auth username, Rclone GUI uses it as well.
   * ARIA2_PWD Basic Auth password, Rclone GUI uses it as well.
   * ARIA2_EXTERNAL_PORT The Aria2 port which exposed to public to access to

--- a/rclone.sh
+++ b/rclone.sh
@@ -1,9 +1,14 @@
 #! /bin/bash -eu
 
-echo "Start Rclone"
-rclone rcd --rc-web-gui \
-  --rc-web-gui-no-open-browser \
-  --rc-addr :5572 \
-  --rc-user $ARIA2_USER \
-  --rc-pass $ARIA2_PWD \
-  --cache-dir /app/.cache
+if [ "$ENABLE_RCLONE" = "true" ]; then
+  echo "Start Rclone, please make sure you can connect to Github website. if not, please set docker env ENABLE_RCLONE=false"
+  rclone rcd --rc-web-gui \
+    --rc-web-gui-no-open-browser \
+    --rc-addr :5572 \
+    --rc-user $ARIA2_USER \
+    --rc-pass $ARIA2_PWD \
+    --cache-dir /app/.cache
+else
+  echo "Skip starting Rclone as it's been disabled"
+  sleep 3650d
+fi


### PR DESCRIPTION
Contributes to #138 #131 
This is super useful when user does not stable connection to Github in China, so the app can't download Rclone web UI which will crash the entire app.