### PR TITLE
Update url paths for ariaNg and filebrowser

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,22 +4,25 @@
 
 {$DOMAIN}
 
-redir /ui /ui/ 301
+redir /ui / 301
+redir /ui/ / 301
 redir /rclone /rclone/ 301
+redir /files /files/ 301
+
+reverse_proxy /jsonrpc 127.0.0.1:6800
 
 route /rclone/* {
   uri strip_prefix /rclone
-  reverse_proxy http://localhost:5572
+  reverse_proxy 127.0.0.1:5572
 }
 
-route /ui/* {
-  uri strip_prefix /ui
-  root * /usr/local/www/aria2
-  file_server
+route /files/* {
+  uri strip_prefix /files
+  reverse_proxy 127.0.0.1:8080
 }
 
-reverse_proxy 127.0.0.1:8080
-reverse_proxy /jsonrpc 127.0.0.1:6800
+root * /usr/local/www/aria2
+file_server
 
 encode gzip
 log {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:edge
 
 LABEL AUTHOR=Junv<wahyd4@gmail.com>
 

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-filebrowser: /app/filebrowser -p 8080 -d /app/filebrowser.db -r /data
+filebrowser: /app/filebrowser -p 8080 -d /app/filebrowser.db -r /data -b /files
 caddy: /app/caddy.sh
 aria2c: /app/aria2c.sh
 rclone: /app/rclone.sh

--- a/README.CN.md
+++ b/README.CN.md
@@ -40,7 +40,7 @@ File Browser
   * 自动 HTTPS （Let's Encrypt）
   * 支持绑定自定义用户ID，可以主机上的非`root`用户，也可以管理下载的文件
   * Basic Auth 用户认证
-  * 文件管理和视频播放 ([File Browser](https://filebrowser.xyz/)，注意默认情况下，只能访问和管理 `/data` 目录下的文件)
+  * 文件管理和视频播放 ([FileBrowser](https://filebrowser.xyz/)，注意默认情况下，只能访问和管理 `/data` 目录下的文件)
   * 支持ARM CPU 架构，因此可以在树莓派等设备上运行，
 
 ## 推荐使用的docker image tag
@@ -57,10 +57,10 @@ File Browser
   docker buildx build --platform linux/arm/v7,linux/arm64,linux/amd64 -t aria2-ui .
 ```
 
-* Aria2: <http://yourip/ui/>
-* FileManger: <http://yourip>
+* Aria2: <http://yourip>
+* Filebrowser: <http://yourip/files>
 * Rclone: <http://yourip/rclone>
-* 请使用 admin/admin 进行登录, 在如果没有修改`ARIA2_USER`,`ARIA2_PWD`的情况下，请使用`user`/`password`登录`Rclone`
+* 请使用 admin/admin 进行登录Filebrowser, 在如果没有修改`ARIA2_USER`,`ARIA2_PWD`的情况下，请使用`user`/`password`登录`Rclone`
 ### 开启所有功能
 ```bash
   docker run -d --name ariang \

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ File Browser
   docker run -d --name aria2-ui -p 80:80 wahyd4/aria2-ui
 ```
 
-* Aria2: <http://yourip/ui/>
-* FileManger: <http://yourip>
+* Aria2: <http://yourip>
+* FileManger: <http://yourip/files>
 * Rclone: <http://yourip/rclone>
-* Please use `admin`/`admin` as username and password to login for the first time, and `user`/`password` to login `Rclone` if you don't update `ARIA2_USER` and `ARIA2_PWD`
+* Please use `admin`/`admin` as username and password to login `Filebrowser` for the first time. And use `user`/`password` to login `Rclone` if you don't update `ARIA2_USER` and `ARIA2_PWD`
 
 ### Full features run
 
@@ -81,7 +81,7 @@ File Browser
   -e DOMAIN=https://example.com \
   -e ARIA2_SSL=false \
   -e ARIA2_USER=user \
-  -e ARIA2_PWD=pwd \
+  -e ARIA2_PWD=password \
   -e ARIA2_EXTERNAL_PORT=443 \
   -v /yourdata:/data \
   -v /app/a.db:/app/filebrowser.db \

--- a/SecureCaddyfile
+++ b/SecureCaddyfile
@@ -4,26 +4,29 @@
 
 {$DOMAIN}
 
-redir /ui /ui/ 301
-redir /rclone /rclone/ 301
-
-route /rclone/* {
-  uri strip_prefix /rclone
-  reverse_proxy http://localhost:5572
-}
-
-route /ui/* {
-  uri strip_prefix /ui
-  root * /usr/local/www/aria2
-  file_server
-}
-
-basicauth /ui/* {
+basicauth /* {
   ARIA2_USER ARIA2_PWD_ENCRYPT
 }
 
-reverse_proxy 127.0.0.1:8080
+redir /ui / 301
+redir /ui/ / 301
+redir /rclone /rclone/ 301
+redir /files /files/ 301
+
 reverse_proxy /jsonrpc 127.0.0.1:6800
+
+route /rclone/* {
+  uri strip_prefix /rclone
+  reverse_proxy 127.0.0.1:5572
+}
+
+route /files/* {
+  uri strip_prefix /files
+  reverse_proxy 127.0.0.1:8080
+}
+
+root * /usr/local/www/aria2
+file_server
 
 encode gzip
 log {


### PR DESCRIPTION
Contributes to #148.

This pull request introduces the changes to address our customers' feedback on URL paths for AriaNg and Filebrowser.

So in the new version, the root path `/` will be AriaNg's URL path and `/files` will be Filebrowser's URL path.