### PR TITLE
create soft link to all user can sync files and folders in rclone

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,4 +72,5 @@ adduser -D -u 1000 junv \
   && rm -rf ${ariang_file} \
   && chmod -R 755 /usr/local/www/aria2 \
   && mkdir -p /data/cloud \
-  && chown junv:junv /data/cloud
+  && chown junv:junv /data/cloud \
+  && ln -s /data/cloud /app


### PR DESCRIPTION
This is an improvement of #168  which creates a `/data/cloud` folder by default and softlinks it to `/app/cloud`, so that users can have some configurations similar to the following to sync files and folders from `/app/cloud` to remote cloud storage providers. I have tested it works.

> Note for the files you'd like to sync to cloud providers, you need to download them to `/data/cloud` or download them to `/data/` and then move them to `/data/cloud` folder

The working rclone.conf looks like below

```
[google drive]
type = drive
client_id = xxx
client_secret = xxx
scope = drive
root_folder_id =
token = {some generated codes by rclone}
team_drive =

[local]
type = local
copy_links = true

```

