### PR TITLE
Dht issue

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,9 @@
-#{
-#  auto_https off
-#}
-
 {$DOMAIN}
+
+log{
+	level ERROR
+	output stderr
+}
 
 redir /ui / 301
 redir /ui/ / 301
@@ -29,6 +30,3 @@ root * /usr/local/www/aria2
 file_server
 
 encode gzip
-log {
-	output stderr
-}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,7 @@
 {$DOMAIN}
 
-log{
-	level ERROR
+log {
+	level {env.CADDY_LOG_LEVEL}
 	output stderr
 }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ENV XDG_DATA_HOME=/app/.caddy/data
 ENV XDG_CONFIG_HOME=/app/.caddy/config
 ENV RCLONE_CONFIG_BASE64=""
 ENV ENABLE_APP_CHECKER=true
+ENV XDG_CACHE_HOME=/app/.cache
 
 ADD install.sh aria2c.sh caddy.sh Procfile init.sh start.sh rclone.sh new-version-checker.sh APP_VERSION /app/
 ADD conf /app/conf
@@ -44,13 +45,16 @@ RUN ./install.sh
 
 RUN rm ./install.sh
 
-# folder for storing ssl keys
-VOLUME /app/conf/key
+# For config files
+VOLUME /app/conf/
 
-# file downloading folder
+# For file downloading
 VOLUME /data
 
-EXPOSE 80 443
+# For rclone cache and aria2 DHT files
+VOLUME /app/.cache
+
+EXPOSE 80 443 6881
 
 HEALTHCHECK --interval=30s --timeout=3s \
   CMD curl -f http://localhost/ping || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,10 @@ ENV CADDYPATH=/app
 ENV RCLONE_CONFIG=/app/conf/rclone.conf
 ENV XDG_DATA_HOME=/app/.caddy/data
 ENV XDG_CONFIG_HOME=/app/.caddy/config
+ENV XDG_CACHE_HOME=/app/.cache
 ENV RCLONE_CONFIG_BASE64=""
 ENV ENABLE_APP_CHECKER=true
-ENV XDG_CACHE_HOME=/app/.cache
+ENV CADDY_LOG_LEVEL=INFO
 
 ADD install.sh aria2c.sh caddy.sh Procfile init.sh start.sh rclone.sh new-version-checker.sh APP_VERSION /app/
 ADD conf /app/conf

--- a/SecureCaddyfile
+++ b/SecureCaddyfile
@@ -1,7 +1,7 @@
 {$DOMAIN}
 
 log {
-	level ERROR
+	level {env.CADDY_LOG_LEVEL}
 	output stderr
 }
 

--- a/SecureCaddyfile
+++ b/SecureCaddyfile
@@ -1,5 +1,10 @@
 {$DOMAIN}
 
+log {
+	level ERROR
+	output stderr
+}
+
 basicauth / {
 	ARIA2_USER ARIA2_PWD_ENCRYPT
 }
@@ -29,6 +34,3 @@ root * /usr/local/www/aria2
 file_server
 
 encode gzip
-log {
-	output stderr
-}

--- a/conf/aria2.conf
+++ b/conf/aria2.conf
@@ -73,3 +73,9 @@ on-download-complete=/app/conf/aria2-sample-hook.sh
 
 # The script to be run when download fails
 on-download-error=/app/conf/aria2-sample-hook.sh
+
+## DHT
+dht-entry-point=dht.transmissionbt.com:6881
+dht-entry-point=dht.vuze.com:6881
+dht-entry-point=dht.libtorrent.org:25401
+dht-listen-port=6881

--- a/init.sh
+++ b/init.sh
@@ -6,6 +6,7 @@ usermod -o -u "$PUID" junv
 
 mkdir -p /app/.caddy
 mkdir -p /app/.cache
+mkdir -p /app/.cache/aria2
 
 chown -R junv:junv \
          /app \


### PR DESCRIPTION
To Address #210 
## Changes

Previously, aria2 would try to write `dht.dat` file under `/root` folder, which would fail because the user running aria2 doesn't have enough permissions. So I decided to move the file to `/app/.cache/aria2`

Now, users can mount `/app/.cache` folder so that the program doesn't need to download rclone web, as well as be able to reuse `dht.dat` file.

Last but not least, support exposing DHT udp port 6881 as well.