### PR TITLE
Support just enable rpc-secret for aria2c

### DIFF
--- a/aria2c.sh
+++ b/aria2c.sh
@@ -1,21 +1,28 @@
-#! /bin/bash -eu
+#! /bin/bash -euo
 
 sed -i 's/6800/'"${ARIA2_EXTERNAL_PORT}"'/g' /usr/local/www/aria2/js/aria-ng*.js
-RPC_SECRET_BASE64=$(echo -n ${RPC_SECRET}|base64)
+RPC_SECRET_BASE64=$(echo -n ${RPC_SECRET} | base64)
 sed -i 's/secret:\"\"/secret:\"'"${RPC_SECRET_BASE64}"'\"/g' /usr/local/www/aria2/js/aria-ng*.js
 
 if [ "$ARIA2_SSL" = "true" ]; then
-echo "[INFO] Start aria2 with secure config"
+  echo "[INFO] Start aria2 with secure config and rpc-secret"
 
-/usr/bin/aria2c --conf-path="/app/conf/aria2.conf" \
---enable-rpc --rpc-listen-all \
---rpc-certificate=/app/conf/key/aria2.crt \
---rpc-private-key=/app/conf/key/aria2.key \
---rpc-secret="$RPC_SECRET" --rpc-secure \
+  /usr/bin/aria2c --conf-path="/app/conf/aria2.conf" \
+    --enable-rpc --rpc-listen-all \
+    --rpc-certificate=/app/conf/key/aria2.crt \
+    --rpc-private-key=/app/conf/key/aria2.key \
+    --rpc-secret="${RPC_SECRET}" --rpc-secure
+
+elif [ "$ARIA2_SSL" = "false" && ${RPC_SECRET} != "" ]; then
+  echo "[INFO] Start aria2 with rpc-secret"
+  /usr/bin/aria2c --conf-path="/app/conf/aria2.conf" \
+    --enable-rpc \
+    --rpc-listen-all \
+    --rpc-secret="${RPC_SECRET}"
 
 else
 
-echo "[INFO] Start aria2 with standard mode"
-/usr/bin/aria2c --conf-path="/app/conf/aria2.conf" --enable-rpc --rpc-listen-all
+  echo "[INFO] Start aria2 with standard mode"
+  /usr/bin/aria2c --conf-path="/app/conf/aria2.conf" --enable-rpc --rpc-listen-all
 
 fi


### PR DESCRIPTION
Previously You have to enable `ARIA2_SSL` by setting it to `true` to enable `rpc-secret`, but you can just set `rpc-secret` itself alone.